### PR TITLE
Fix update pod ephermalmetadata

### DIFF
--- a/.github/workflows/image-reuse.yaml
+++ b/.github/workflows/image-reuse.yaml
@@ -79,7 +79,7 @@ jobs:
           cosign-release: 'v2.2.0'
 
       - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Setup tags for container image as a CSV type
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Generate release artifacts
         run: |


### PR DESCRIPTION
I've added a unit test and fixed the following bugs:

- const DefaultEphemeralMetadataPodRetries and the comment had a mismatch
- retry didn't have backoff
- if podModified was false, it would have resulted in an infinite loop because the counter was only incrementing if it was true
- 'retryLimit' isn't a an accurate description of what the variable is used for. renamed to 'attempt'
- err from pod conflict was ignored, now it logs the error
- err after retries has exhausted was ignored, now it returns the last err
